### PR TITLE
ignore paths that do not lead to the specified trace

### DIFF
--- a/src/examples/features/simple/test_foo.jpf
+++ b/src/examples/features/simple/test_foo.jpf
@@ -2,5 +2,6 @@
 
 concolic.method=foo
 
+jdart.configs.all_fields_symbolic.decision_trace=11
 
 

--- a/src/main/gov/nasa/jpf/jdart/config/AnalysisConfig.java
+++ b/src/main/gov/nasa/jpf/jdart/config/AnalysisConfig.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Predicate;
@@ -110,6 +111,8 @@ public class AnalysisConfig {
 
   private boolean loadAxioms = false;
   
+  private int[] decisionTrace = null;
+  
   public void parse(String prefix, Config config) {
     String maxDepthKey = prefix + ".max_depth";
     if(config.hasValue(maxDepthKey)) {
@@ -170,6 +173,21 @@ public class AnalysisConfig {
       setSymbolicFieldsInclude(symbInclStr);
     }
     
+    String decisionTraceKey = prefix + ".decision_trace";
+    if(config.hasValue(decisionTraceKey)) {
+      String decisionTraceStr = config.getString(decisionTraceKey);
+      parseTrace(decisionTraceStr);
+    }
+  }
+  
+  private void parseTrace(String decisionTraceStr) {
+    decisionTrace = decisionTraceStr.chars()
+        .map(c -> Character.getNumericValue(c))
+        .toArray();
+  }
+  
+  public Optional<int[]> getDecisionTrace() {
+    return Optional.ofNullable(decisionTrace);
   }
   
   public int getTreeMaxDepth() {

--- a/src/main/gov/nasa/jpf/jdart/constraints/InternalConstraintsTree.java
+++ b/src/main/gov/nasa/jpf/jdart/constraints/InternalConstraintsTree.java
@@ -28,6 +28,7 @@ import gov.nasa.jpf.util.Pair;
 import gov.nasa.jpf.vm.Instruction;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -461,6 +462,38 @@ public class InternalConstraintsTree {
           currentTarget.dontKnow();
           continue;
         }
+        // (guided JDart execution) check if the current trace is a prefix of the target decision trace  
+        if (anaConf.getDecisionTrace().isPresent()) {
+          int[] decisionTrace = anaConf.getDecisionTrace().get();
+          int[] currentTrace = tracePathToNode(currentTarget);
+
+          if (logger.isFineLogged()) {
+            logger.fine("target  trace: ", Arrays.toString(decisionTrace));
+            logger.fine("current trace: ", Arrays.toString(currentTrace));
+          }
+          //FIXME what should we do if the target trace is a prefix of the current trace?  
+          int size = Math.min(decisionTrace.length, currentTrace.length);
+          boolean isPrefix = true;
+          for (int i = 0; i < size; i++) {
+            if (decisionTrace[i] != currentTrace[i]) {
+              isPrefix = false;
+              break;
+            }
+          }
+          if (!isPrefix) {
+            logger.fine("skipping node: ", currentTarget);
+            currentTarget.dontKnow();
+            continue;
+          }
+          if (currentTrace.length >= decisionTrace.length) {
+            //TODO we found our target, do whatever you want here
+            logger.fine("Target path found! continuing...");
+            System.out.println();
+          } else {
+            logger.fine("prefix found! continuing...");
+          }
+        }
+        
         Valuation val = new Valuation();
         logger.finer("Finding new valuation");
         Result res = solverCtx.solve(val);
@@ -524,6 +557,32 @@ public class InternalConstraintsTree {
     }
 
     return null;
+  }
+
+  private int[] tracePathToNode(Node target) {
+    int depth = target.depth;
+    int[] trace = new int[depth];
+    Node current = target;
+    
+    for (int i = depth - 1; i >= 0; i--) {
+      Node parent = current.getParent();
+      DecisionData decisions = parent.decisionData();
+      int choice = 0;
+      for (Node child : decisions.children) {
+        //not sure why child can be null here - maybe the array is populated lazily?
+        if (child != null && child.equals(current)) {
+          break;
+        }
+        choice++;
+      }
+      if (choice > decisions.children.length) {
+        throw new RuntimeException("Is this really the parent for this node? " + parent);
+      }
+      trace[i] = choice;
+      current = parent;
+    }
+    
+    return trace;
   }
 
   public ConstraintsTree toFinalCTree() {


### PR DESCRIPTION
Hey guys,

I sketched a "guided exploration" for jDart. In a nutshell, every time jDart requests a new 'valuation' (i.e. set of concrete inputs) it checks if the patch leading to the current node is a prefix of a given trace. If not, the node is skipped. Ping me if you have any questions. 